### PR TITLE
Ajusta chamada para não haver caso recursivo.

### DIFF
--- a/DanfeSharp/Formatador.cs
+++ b/DanfeSharp/Formatador.cs
@@ -61,7 +61,7 @@ namespace DanfeSharp
         public static String FormatarEnderecoLinha1(String endereco, int? numero, String complemento = null)
         {
             String sNumero = numero.HasValue ? numero.Value.ToString() : null;
-            return FormatarEnderecoLinha1(endereco, numero, complemento);
+            return FormatarEnderecoLinha1(endereco, sNumero, complemento);
         }
 
         /// <summary>


### PR DESCRIPTION
Foi verificado, caso seja passado um numero, ele não irá repassar para o método 

static String FormatarEnderecoLinha1(String endereco, String numero = null, String complemento = null).

se for passado um int? com valor para o método, ele hoje não passa o String, e mantém o int assim, chamando recursivamente o mesmo.